### PR TITLE
Update atomic-deploy.php

### DIFF
--- a/atomic-deploy.php
+++ b/atomic-deploy.php
@@ -366,7 +366,8 @@ class Deployer {
                 $output, $returnVar);
 
             if ($returnVar > 0) {
-                throw new RuntimeException('Could not prune old revisions' . $output);
+                echo 'Could not prune old revisions' . PHP_EOL;
+                print_r($output);
             }
         }
     }


### PR DESCRIPTION
Created this change specifically for Hines.com, but we might want to add it to the main script for other sites.

Previously this script was throwing an exception when it failed to prune old revisions. Normally, this is a good thing, but since we don't always control the server top to bottom, sometimes a user with higher permissions than us adds something into a revision and our script is no longer allowed to delete it.

This updates the script to not throw an exception in that case, and instead just leave the files be and continue on our merry way.

We probably want to add this idea more throughout the script so that it fails more gracefully, the main problem is if the script fails, Buddy bails out and important items that run _after_ it end up not running and taking the site down.