### PR TITLE
Password Protect on Deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ rm -rf revisions/<revision_id>/logs \
   && ln -sfn <deploy-dir>/shared/logs revisions/<revision>/logs
 ```
 
+## Password Protection
+By default, the deployment will password protect any site that is served from a *.oneis.us domain name. This works by prepending the contents of the `templates/htaccess-auth.txt` file to any existing `.htaccess` file found in the `current/web` directory. If an `.htaccess` file does not exist within that directory, one will be generated using the `templates/htaccess.txt` file.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ rm -rf revisions/<revision_id>/logs \
 
 ```bash
 cd ./test
-php ../atomic-deploy.php \
+php ../bin/deploy \
   --deploy-cache-dir="./deploy-cache" \
   --revision="123456" \
   --symlinks='{"shared/config/env":".env","shared/storage":"storage"}'

--- a/atomic-deploy.php
+++ b/atomic-deploy.php
@@ -3,7 +3,7 @@
 /*
  */
 
-process(is_array($argv) ? $argv : array());
+process(is_array($argv) ? $argv : []);
 
 /**
  * processes the installer
@@ -18,8 +18,8 @@ function process($argv)
         exit(0);
     }
 
-    $help       = in_array('--help', $argv);
-    $quiet      = in_array('--quiet', $argv);
+    $help = in_array('--help', $argv);
+    $quiet = in_array('--quiet', $argv);
     $deployDir = getOptValue('--deploy-dir', $argv, getcwd());
     $deployCacheDir = getOptValue('--deploy-cache-dir', $argv, 'deploy-cache');
     $revision = getOptValue('--revision', $argv, false);
@@ -118,7 +118,7 @@ function getOptValue($opt, $argv, $default)
  * @param mixed $deployDir The required deployment directory
  * @param mixed $deployCacheDir The required deployment cache directory
  * @param mixed $revision A unique ID for this revision
- * @param mixed $revisionsToKeep The number of revisions to keep after deploying 
+ * @param mixed $revisionsToKeep The number of revisions to keep after deploying
  *
  * @return bool True if the supplied params are okay
  */
@@ -159,11 +159,11 @@ function checkParams($deployDir, $deployCacheDir, $revision, $revisionsToKeep, $
  */
 function out($text, $color = null, $newLine = true)
 {
-    $styles = array(
+    $styles = [
         'success' => "\033[0;32m%s\033[0m",
         'error' => "\033[31;31m%s\033[0m",
         'info' => "\033[33;33m%s\033[0m"
-    );
+    ];
 
     $format = '%s';
 
@@ -178,18 +178,19 @@ function out($text, $color = null, $newLine = true)
     printf($format, $text);
 }
 
-class Deployer {
+class Deployer
+{
 
     private $quiet;
     private $deployPath;
     private $revisionPath;
     private $errHandler;
 
-    private $directories = array(
+    private $directories = [
         'revisions' => 'revisions',
         'shared' => 'shared',
         'config' => 'shared/config',
-        );
+    ];
 
     /**
      * Constructor - must not do anything that throws an exception
@@ -205,9 +206,10 @@ class Deployer {
     }
 
     /**
-     * 
+     *
      */
-    public function run($deployDir, $deployCacheDir, $revision, $revisionsToKeep, $symLinks) {
+    public function run($deployDir, $deployCacheDir, $revision, $revisionsToKeep, $symLinks)
+    {
         try {
             out('Creating atomic deployment directories...');
             $this->initDirectories($deployDir);
@@ -242,20 +244,22 @@ class Deployer {
             }
             out($e->getMessage(), 'error');
         }
-        return $result;   
+        return $result;
     }
 
     /**
      * [initDirectories description]
-     * @param  string $deployDir Base deployment directory
+     *
+     * @param string $deployDir Base deployment directory
      * @return void
      * @throws RuntimeException If the deploy directory is not writable or dirs can't be created
      */
-    public function initDirectories($deployDir) {
+    public function initDirectories($deployDir)
+    {
         $this->deployPath = (is_dir($deployDir) ? rtrim($deployDir, '/') : '');
 
         if (!is_writeable($deployDir)) {
-            throw new RuntimeException('The deploy directory "'.$deployDir.'" is not writable');
+            throw new RuntimeException('The deploy directory "' . $deployDir . '" is not writable');
         }
 
         if (!is_dir($this->directories['revisions']) && !mkdir($this->directories['revisions'])) {
@@ -273,10 +277,12 @@ class Deployer {
 
     /**
      * Creates a revision directory under the revisions/ directory
+     *
      * @throws RuntimeException If directories can't be created
      */
-    public function createRevisionDir($revision) {
-        $this->revisionPath = $this->deployPath . DIRECTORY_SEPARATOR . $this->directories['revisions']. DIRECTORY_SEPARATOR . $revision;
+    public function createRevisionDir($revision)
+    {
+        $this->revisionPath = $this->deployPath . DIRECTORY_SEPARATOR . $this->directories['revisions'] . DIRECTORY_SEPARATOR . $revision;
         $this->revisionPath = rtrim($this->revisionPath, DIRECTORY_SEPARATOR);
 
         // Check to see if this revision was already deployed
@@ -289,20 +295,21 @@ class Deployer {
         }
 
         if (!is_writeable($this->revisionPath)) {
-            throw new RuntimeException('The revision directory "'.$this->revisionPath.'" is not writable');
+            throw new RuntimeException('The revision directory "' . $this->revisionPath . '" is not writable');
         }
     }
 
     /**
      * Copies the deploy-cache to the revision directory
      */
-    public function copyCacheToRevision($deployCacheDir) {
+    public function copyCacheToRevision($deployCacheDir)
+    {
         $this->errHandler->start();
 
         exec("cp -a $deployCacheDir/. $this->revisionPath", $output, $returnVar);
 
         if ($returnVar > 0) {
-            throw new RuntimeException('Could not copy deploy cache to revision directory: ' . $output); 
+            throw new RuntimeException('Could not copy deploy cache to revision directory: ' . $output);
         }
 
         $this->errHandler->stop();
@@ -311,10 +318,11 @@ class Deployer {
     /**
      * Creates defined symbolic links
      */
-    public function createSymLinks($symLinks) {
+    public function createSymLinks($symLinks)
+    {
         $this->errHandler->start();
 
-        foreach($symLinks as $target => $linkName) {
+        foreach ($symLinks as $target => $linkName) {
             $t = $this->deployPath . DIRECTORY_SEPARATOR . $target;
             $l = $this->revisionPath . DIRECTORY_SEPARATOR . $linkName;
 
@@ -331,7 +339,8 @@ class Deployer {
     /**
      * Sets the deployed revision as `current`
      */
-    public function linkCurrentRevision() {
+    public function linkCurrentRevision()
+    {
         $this->errHandler->start();
 
         $revisionTarget = $this->revisionPath;
@@ -341,7 +350,7 @@ class Deployer {
             $this->createSymLink($revisionTarget, $currentLink);
         } catch (Exception $e) {
             throw new RuntimeException("Could not create current symlink: " . $e->getMessage());
-        } 
+        }
 
         $this->errHandler->stop();
     }
@@ -349,7 +358,8 @@ class Deployer {
     /**
      * Removes old revision directories
      */
-    public function pruneOldRevisions($revisionsToKeep) {
+    public function pruneOldRevisions($revisionsToKeep)
+    {
         if ($revisionsToKeep > 0) {
             $revisionsDir = $this->deployPath . DIRECTORY_SEPARATOR . $this->directories['revisions'];
 
@@ -362,7 +372,7 @@ class Deployer {
             $rmIndex = $revisionsToKeep + 2;
 
             // ls 1 directory by time modified | collect all dirs from ${revisionsToKeep} line of output | translate newlines and nulls | remove all those dirs
-            exec("ls -1dtp ${revisionsDir}/** | tail -n +${rmIndex} | tr " . '\'\n\' \'\0\'' ." | xargs -0 rm -rf --",
+            exec("ls -1dtp ${revisionsDir}/** | tail -n +${rmIndex} | tr " . '\'\n\' \'\0\'' . " | xargs -0 rm -rf --",
                 $output, $returnVar);
 
             if ($returnVar > 0) {
@@ -374,7 +384,8 @@ class Deployer {
     /**
      * Uses the system method `ln` to create a symlink
      */
-    protected function createSymLink($target, $linkName) {
+    protected function createSymLink($target, $linkName)
+    {
         exec("rm -rf $linkName && ln -sfn $target $linkName", $output, $returnVar);
 
         if ($returnVar > 0) {
@@ -406,7 +417,7 @@ class Deployer {
     protected function outputErrors()
     {
         $errors = explode(PHP_EOL, ob_get_clean());
-        $shown = array();
+        $shown = [];
 
         foreach ($errors as $error) {
             if ($error && !in_array($error, $shown)) {
@@ -455,7 +466,7 @@ class ErrorHandler
     public function start()
     {
         if (!$this->active) {
-            set_error_handler(array($this, 'handleError'));
+            set_error_handler([$this, 'handleError']);
             $this->active = true;
         }
         $this->message = '';

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,11 @@
             "email": "brian@onedesigncompany.com"
         }
     ],
-    "require": {}
+    "require": {},
+    "config": {
+        "sort-packages": true,
+        "platform": {
+            "php":  "7.2.5"
+        }
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,18 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "7a70f8ca941225adb0fdfd40d28d5248",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
+}

--- a/templates/htaccess-auth.txt
+++ b/templates/htaccess-auth.txt
@@ -1,0 +1,38 @@
+# ----------------------------------------------------------------------
+# AUTH
+# ----------------------------------------------------------------------
+
+# Begin Auth stuff: https://stackoverflow.com/questions/1359472/use-http-auth-only-if-accessing-a-specific-domain
+# Require a username & password if we're on a *.oneis.us domain
+SetEnvIfNoCase Host oneis\.us$ require_auth=true
+
+AuthUserFile %{AUTH_FILE_PATH}
+AuthName "Password Protected"
+AuthType Basic
+
+Order Deny,Allow
+Deny from all
+Satisfy any
+Require valid-user
+Allow from env=!require_auth
+
+# Allow siteimprove IPs
+Allow from 93.160.60.22
+Allow from 185.229.144.22
+Allow from 80.62.246.50
+Allow from 52.48.230.149
+Allow from 52.57.25.76
+Allow from 3.10.81.130
+Allow from 35.157.236.87
+Allow from 35.157.42.7
+Allow from 52.55.30.145
+Allow from 52.20.183.91
+Allow from 52.60.34.56
+Allow from 185.229.144.10
+Allow from 52.7.141.1
+Allow from 52.4.143.42
+Allow from 52.64.209.168
+Allow from 52.47.166.84
+Allow from 35.204.24.17
+Allow from 52.199.41.160
+Allow from 35.156.240.123

--- a/templates/htaccess.txt
+++ b/templates/htaccess.txt
@@ -1,0 +1,64 @@
+# ----------------------------------------------------------------------
+# Rewrites
+# ----------------------------------------------------------------------
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+
+    # This sets the environment variable HTTPS to "on"
+    # if the request is behind a load balancer which terminates SSL.
+    # In PHP, you can access this via $_SERVER['HTTPS']
+    SetEnvIf X-Forwarded-Proto https HTTPS=on
+
+    # Force redirect to HTTPS
+    # Uncomment the rules below to enable. If hosting on Cloudways, these rules do not need to be enabled: https://support.cloudways.com/redirect-http-to-https/
+    # RewriteCond %{HTTPS} off
+    # RewriteCond %{HTTP:X-Forwarded-Proto} !https [NC]
+    # RewriteCond %{HTTP_HOST} ^www.example.com [NC,OR]
+    # RewriteCond %{HTTP_HOST} ^.+\.oneis.us [NC]
+    # RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+
+    # Redirect non-www to www
+    # Uncomment the rules below to enable
+    # RewriteCond %{HTTP_HOST} ^example.com [NC]
+    # RewriteRule ^(.*)$ https://www.example.com/$1 [L,R=301,NC]
+
+    # Strip trailing slashes from the end of URLs. Redirect them to non-slash versions.
+    # This ignores the trailing slash on the base URL (e.g. https://www.example.com/)
+    RewriteCond %{REQUEST_URI} ^.+\/$
+    RewriteRule ^(.+)\/$ /$1 [L,R=301,NC]
+
+    # Blitz cache rewrite
+    # https://putyourlightson.com/craft-plugins/blitz/docs#/?id=server-rewrites
+    RewriteCond %{DOCUMENT_ROOT}/cache/blitz/%{HTTP_HOST}/%{REQUEST_URI}/%{QUERY_STRING}/index.html -s
+    RewriteCond %{REQUEST_METHOD} GET
+    # Required as of version 2.1.0
+    RewriteCond %{QUERY_STRING} !token= [NC]
+    RewriteRule .* /cache/blitz/%{HTTP_HOST}/%{REQUEST_URI}/%{QUERY_STRING}/index.html [L]
+
+    # Send would-be 404 requests to Craft
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_URI} !^/(favicon\.ico|apple-touch-icon.*\.png)$ [NC]
+    RewriteRule (.+) index.php?p=$1 [QSA,L]
+</IfModule>
+
+# ----------------------------------------------------------------------
+# Security headers
+# ----------------------------------------------------------------------
+<IfModule mod_headers.c>
+
+  # Stop pages from loading when they detect XSS attacks
+  Header set X-XSS-Protection "1; mode=block"
+
+  # Disable the ablity to render a page on this website in a '<frame>', '<iframe>' or '<object>'
+  Header set X-Frame-Options "SAMEORIGIN"
+
+  # Enable HSTS, which instructs clients to only connect to a website over encrypted HTTPS connections
+  Header set Strict-Transport-Security "max-age=31536000" env=HTTPS
+
+  # Protect against content-sniffing, page-framing and click-jacking, xss attacks
+  # https://htaccessbook.com/increase-security-x-security-headers/
+  Header set X-XSS-Protection "1; mode=block"
+  Header always append X-Frame-Options SAMEORIGIN
+  Header set X-Content-Type-Options nosniff
+</IfModule>

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,5 @@
-releases/*
-current
+*
+!.gitignore
+
+!deploy-cache
+!shared


### PR DESCRIPTION
Adds a post deployment action that will password protect any site served from a .oneis.us domain. 

We password protect these sites but doing 1 of 2 things:

If there's an .htaccess file within the current/web directory after deploy, we prepend the contents of the templates/htaccess-auth.txt file to the existing .htaccess file. If no .htaccess exists, we use the contents of templates/htaccess.txt to create one, and then prepend the same auth content to that file.

The goal is to password protect sites on .oneis.us domains by default without causing any disruption to local environments and without requiring each dev to configure their own projects.