### PR TITLE
Update htaccess.txt

### DIFF
--- a/templates/htaccess.txt
+++ b/templates/htaccess.txt
@@ -61,4 +61,9 @@
   Header set X-XSS-Protection "1; mode=block"
   Header always append X-Frame-Options SAMEORIGIN
   Header set X-Content-Type-Options nosniff
+  
+  # Allow special headers for blitz CORs requests
+  # Honestly, not sure why we need this, but from time to time dynamic Blitz requests fail without it.
+  Header add Access-Control-Allow-Headers "x-requested-with"
+  Header add Access-Control-Allow-Methods "GET, OPTIONS"
 </IfModule>


### PR DESCRIPTION
Vesalius has issues making the dynamic Blitz request from time to time. The issue seems to be due to some headers Blitz automatically includes not being allowed by our server. This allows those headers so everyone is happier overall.